### PR TITLE
Fix device context in generate script

### DIFF
--- a/inference/generate.py
+++ b/inference/generate.py
@@ -112,8 +112,7 @@ def main(
     with open(config) as f:
         args = ModelArgs(**json.load(f))
     print(args)
-    with torch.device("cuda"):
-        model = Transformer(args)
+    model = Transformer(args).cuda()
     tokenizer = AutoTokenizer.from_pretrained(ckpt_path)
     tokenizer.decode(generate(model, [tokenizer.encode("DeepSeek")], 2, -1, 1.)[0])
     load_model(model, os.path.join(ckpt_path, f"model{rank}-mp{world_size}.safetensors"))


### PR DESCRIPTION
## Summary
- ensure generate script moves model to CUDA without using invalid context manager

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python inference/generate.py --help` *(fails: ModuleNotFoundError: No module named 'torch')*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_684187a7c364832095547179b40e80f9)